### PR TITLE
Make `grab` and `attack` true class attributes of Actors

### DIFF
--- a/ascifight/board/data.py
+++ b/ascifight/board/data.py
@@ -2,6 +2,7 @@ import abc
 import sys
 import itertools
 import os
+import typing
 
 from pydantic import BaseModel, Field
 import toml
@@ -85,8 +86,8 @@ class Flag(BoardObject):
 class Actor(BoardObject, abc.ABC):
     ident: int
     team: Team
-    grab = 0.0
-    attack = 0.0
+    grab: typing.ClassVar[float] = 0.0
+    attack: typing.ClassVar[float] = 0.0
     build = 0.0
     destroy = 0.0
     flag: Flag | None = None
@@ -112,16 +113,16 @@ class Actor(BoardObject, abc.ABC):
 
 
 class Generalist(Actor):
-    grab = 1.0
-    attack = 1.0
+    grab: typing.ClassVar[float] = 1.0
+    attack: typing.ClassVar[float] = 1.0
 
 
 class Runner(Actor):
-    grab = 1.0
+    grab: typing.ClassVar[float] = 1.0
 
 
 class Attacker(Actor):
-    attack = 1.0
+    attack: typing.ClassVar[float] = 1.0
 
 
 class Guardian(Actor):


### PR DESCRIPTION
Due to the use of pydantic.BaseModel as base class, these are not class attributes. However, they are used as such in get_properties, causing an internal server error when the rules are queried.