### PR TITLE
3d view

### DIFF
--- a/ascifight/board/data.py
+++ b/ascifight/board/data.py
@@ -2,6 +2,7 @@ import abc
 import sys
 import itertools
 import os
+import typing
 
 from pydantic import BaseModel, Field
 import toml
@@ -85,8 +86,8 @@ class Flag(BoardObject):
 class Actor(BoardObject, abc.ABC):
     ident: int
     team: Team
-    grab = 0.0
-    attack = 0.0
+    grab: typing.ClassVar[float] = 0.0
+    attack: typing.ClassVar[float] = 0.0
     build = 0.0
     destroy = 0.0
     flag: Flag | None = None
@@ -112,16 +113,16 @@ class Actor(BoardObject, abc.ABC):
 
 
 class Generalist(Actor):
-    grab = 1.0
-    attack = 1.0
+    grab: typing.ClassVar[float] = 1.0
+    attack: typing.ClassVar[float] = 1.0
 
 
 class Runner(Actor):
-    grab = 1.0
+    grab: typing.ClassVar[float] = 1.0
 
 
 class Attacker(Actor):
-    attack = 1.0
+    attack: typing.ClassVar[float] = 1.0
 
 
 class Guardian(Actor):

--- a/ascifight/view_3D.py
+++ b/ascifight/view_3D.py
@@ -101,6 +101,12 @@ Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
 
     def move_vobject(self, object_id, pos):
         if object_id in self.dynamic_vobjects:
+            old_pos = self.dynamic_vobjects[object_id].pos
+            if old_pos != pos:
+                dpos = (pos - old_pos) / 10
+                for i in range(10):
+                    self.dynamic_vobjects[object_id].pos += dpos
+                    vpython.rate(60)
             self.dynamic_vobjects[object_id].pos = pos
             self.dynamic_vobjects[object_id].ascifight_update = True
             return True

--- a/ascifight/view_3D.py
+++ b/ascifight/view_3D.py
@@ -122,17 +122,24 @@ Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
             color = self.team_to_color(game_object['team'])
             self.dynamic_vobjects[v_id] = drawer(pos, color)
 
-    def draw_bases(self):
-        for i, base in enumerate(self.state['bases']):
-            v_id = f'base_{i}'
-            self.move_or_create(v_id, base, self.new_base)
-
     def new_base(self, pos, color):
         return vpython.cylinder(pos=pos, axis=vpython.vector(0, 0, 0.5), radius=0.45,
                                 color=color)
 
     def new_runner(self, pos, color):
         return vpython.cone(pos=pos, color=color, radius=0.3, axis=vpython.vector(0, 0, 1))
+
+    def new_flag(self, pos, color):
+        handle = vpython.cylinder(color=vpython.vector(0.72, 0.42, 0), axis=vpython.vector(0, 0, 3), radius=0.05,
+                                  pos=pos)
+        head = vpython.box(color=color, pos=pos + vpython.vector(0, 0.5, 3), length=0.1, width=1, height=1)
+        flag = vpython.compound([handle, head], origin=pos)
+        return flag
+
+    def draw_bases(self):
+        for i, base in enumerate(self.state['bases']):
+            v_id = f'base_{i}'
+            self.move_or_create(v_id, base, self.new_base)
 
     def draw_actors(self):
         for i, actor in enumerate(self.state['actors']):
@@ -143,10 +150,16 @@ Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
             draw_function = self.actor_drawer[actor_type]
             self.move_or_create(v_id, actor, draw_function)
 
+    def draw_flags(self):
+        for i, flag in enumerate(self.state['flags']):
+            v_id = f'flag_{i}'
+            self.move_or_create(v_id, flag, self.new_flag)
+
     def update(self):
         self.new_step()
         self.draw_bases()
         self.draw_actors()
+        self.draw_flags()
         print(self.state)
         self.cleanup()
 

--- a/ascifight/view_3D.py
+++ b/ascifight/view_3D.py
@@ -66,9 +66,15 @@ Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
         vpython.scene.center = vpython.vector(map_size / 2, map_size / 2, 0)
         for x in range(map_size):
             for y in range(map_size):
-                new_square = vpython.box(pos=vpython.vector(x, y, 0), length=1, width=0.1, height=1)
-                new_square.color = (vpython.color.white, vpython.color.black)[(x + y) % 2]
+                new_square = vpython.box(pos=vpython.vector(x, y, 0), length=1, width=0.1, height=1,
+                                         color=(vpython.color.white, vpython.color.black)[(x + y) % 2])
                 self.vobjects[f'square_{x}_{y}'] = new_square
+            new_text_x = vpython.text(pos=vpython.vector(x - 0.4, -1, 0), align='left', color=vpython.color.white,
+                                      height=0.8, depth=0.1, text=str(x), axis=vpython.vector(0, -1, 0))
+            new_text_y = vpython.text(pos=vpython.vector(-1, x - 0.4, 0), align='right', color=vpython.color.white,
+                                      height=0.8, depth=0.1, text=str(x))
+            self.vobjects[f'label_x_{x}'] = new_text_x
+            self.vobjects[f'label_y_{x}'] = new_text_y
 
     def update_vobject(self, object_id, **kwargs):
         if object_id in self.vobjects:

--- a/ascifight/view_3D.py
+++ b/ascifight/view_3D.py
@@ -1,0 +1,118 @@
+import time
+
+import httpx
+import vpython
+
+import ascifight.client
+import ascifight.util
+
+
+class CachedGameInfo:
+    def __init__(self):
+        self.api_cache = {}
+
+    def reset(self):
+        self.api_cache = {}
+
+    def information(self, information):
+        return self.api_cache.get(information, ascifight.client.get_information(information))
+
+
+class AsciFight3D:
+    def __init__(self):
+        self.vobjects = {}
+        self.game_information = CachedGameInfo()
+        vpython.scene.width = 800
+        vpython.scene.height = 800
+
+    def team_to_color(self, team):
+        index = self.state['teams'].index(team)
+        color_name = ascifight.util.color_names[index]
+        return getattr(vpython.color, color_name)
+
+    @property
+    def timing(self):
+        return self.game_information.information('timing')
+
+    @property
+    def rules(self):
+        return self.game_information.information('game_rules')
+
+    @property
+    def state(self):
+        return self.game_information.information('game_state')
+
+    def reset(self):
+        for ref, vobject in list(self.vobjects):
+            vobject.visible = False
+            del self.vobjects[ref]
+        assert len(self.vobjects) == 0
+        self.initialize_board()
+
+    def set_caption(self):
+        vpython.scene.caption = f"""Current score: {self.state['scores']}. 
+Current tick: {self.timing['tick']} 
+
+To rotate "camera", drag with right button or Ctrl-drag.
+To zoom, drag with middle button or Alt/Option depressed, or use scroll wheel.
+On a two-button mouse, middle is left + right.
+To pan left/right and up/down, Shift-drag.
+Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
+
+    def initialize_board(self):
+        self.game_information.reset()
+        self.set_caption()
+        map_size = self.rules['map_size']
+        vpython.scene.center = vpython.vector(map_size / 2, map_size / 2, 0)
+        for x in range(map_size):
+            for y in range(map_size):
+                new_square = vpython.box(pos=vpython.vector(x, y, 0), length=1, width=0.1, height=1)
+                new_square.color = (vpython.color.white, vpython.color.black)[(x + y) % 2]
+                self.vobjects[f'square_{x}_{y}'] = new_square
+
+    def update_vobject(self, object_id, **kwargs):
+        if object_id in self.vobjects:
+            for arg, value in kwargs.items():
+                setattr(self.vobjects[object_id], arg, value)
+            return True
+        return False
+
+    def draw_bases(self):
+        for i, base in enumerate(self.state['bases']):
+            color = self.team_to_color(base['team'])
+            pos = vpython.vector(base['coordinates']['x'], base['coordinates']['y'], 0)
+            v_id = f'base_{i}'
+            if not self.update_vobject(v_id, pos=pos, color=color):
+                self.vobjects[v_id] = vpython.cylinder(pos=pos, axis=vpython.vector(0, 0, 0.5), radius=0.45,
+                                                       color=color)
+
+    def update(self):
+        self.game_information.reset()
+        self.set_caption()
+
+        self.draw_bases()
+
+
+def game_loop():
+    view3d = AsciFight3D()
+    current_tick = 2 ** 100
+    while True:
+        try:
+            timing = ascifight.client.get_information("timing")
+            if timing["tick"] != current_tick:
+                if timing["tick"] < current_tick:
+                    view3d.reset()
+                view3d.update()
+                current_tick = timing["tick"]
+
+            sleep_duration_time = timing["time_to_next_execution"]
+            if sleep_duration_time >= 0:
+                time.sleep(sleep_duration_time)
+        except httpx.ConnectError:
+            current_tick = 2 ** 100
+            time.sleep(10)
+            continue
+
+
+if __name__ == "__main__":
+    game_loop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ context-logging = "^1.1.0"
 toml = "^0.10.2"
 pillow = "^9.5.0"
 httpx = "^0.24.0"
+vpython = "^7.6.4"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
A (client-side) 3D viewer for the game state, based on vpython.

No walls or special actors yet, but should be easy to add. 

Also, no attack animations because attack actions are not part of the game API and can at best be guessed indirectly from changes to the game state.

To use, run view_3d.py. The script will use the config in client.py to fetch the state from the game server, then opens a view in the default web browser. Best combined with some other kind of client that causes changes to the game state.