### PR TITLE
Fix an uncaught exception if game is restarted with fewer teams

### DIFF
--- a/ascifight/game.py
+++ b/ascifight/game.py
@@ -231,7 +231,7 @@ class Game:
                     try:
                         self.overall_scores[self.board.names_teams[team]] += score
                     # ignore score if team is not in current teams
-                    except ValueError:
+                    except KeyError:
                         pass
         # if the file is not yet there assume default scores
         except FileNotFoundError:


### PR DESCRIPTION
A dictionary raises a KeyError, not a ValueError, if an entry does not exist.